### PR TITLE
Added support for different formats

### DIFF
--- a/examples/config.neon
+++ b/examples/config.neon
@@ -8,6 +8,7 @@ webimages:
 
 	routes:
 		- 'images/<id>-<width>x<height>.jpg'
+		- 'images/<id>-<width>x<height>.png'
 
 	rules:
 		- [width: 300, height: 200]

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -15,6 +15,10 @@ use Nette\Utils\Image;
 class Generator extends Nette\Object
 {
 
+	const FORMAT_JPEG = Image::JPEG;
+	const FORMAT_PNG = Image::PNG;
+	const FORMAT_GIF = Image::GIF;
+
 	/** @var string */
 	private $wwwDir;
 
@@ -65,7 +69,7 @@ class Generator extends Nette\Object
 	 * @param  int
 	 * @param  int
 	 */
-	public function generateImage($id, $width, $height, $algorithm)
+	public function generateImage($format, $id, $width, $height, $algorithm)
 	{
 		if (!$this->validator->validate($width, $height, $algorithm)) {
 			throw new Application\BadRequestException;
@@ -95,7 +99,7 @@ class Generator extends Nette\Object
 			}
 		}
 
-		$success = $image->save($destination, 90, Image::JPEG);
+		$success = $image->save($destination, 90, $format);
 		if (!$success) {
 			throw new Application\BadRequestException;
 		}

--- a/src/Route.php
+++ b/src/Route.php
@@ -20,17 +20,22 @@ class Route extends Application\Routers\Route
 	/** @var Generator */
 	private $generator;
 
+	/** @var string */
+	private $format;
+
 
 
 	/**
 	 * @param  string
+	 * @param  string
 	 * @param  array
 	 * @param  Validator
 	 */
-	public function __construct($mask, array $defaults, Generator $generator)
+	public function __construct($mask, $format, array $defaults, Generator $generator)
 	{
 		$this->defaults = array_replace($this->defaults, $defaults);
 		$this->generator = $generator;
+		$this->format = $format;
 
 		$defaults[NULL][self::FILTER_OUT] = function ($params) use ($defaults, $generator) {
 			$width = $this->acquireArgument('width', $params);
@@ -79,7 +84,7 @@ class Route extends Application\Routers\Route
 		$height = $this->acquireArgument('height', $params);
 		$algorithm = $this->acquireArgument('algorithm', $params);
 
-		$this->generator->generateImage($id, $width, $height, $algorithm);
+		$this->generator->generateImage($this->format, $id, $width, $height, $algorithm);
 	}
 
 }


### PR DESCRIPTION
Support for:
- jpeg
- png
- gif

Format is autodetected:

```yaml
routes:
    - <id>/<width>x<height>.png
```

Or can be specified like this:

```yaml
routes:
    - mask: "<id>/<width [0-9]+>x<height [0-9]+>"
      format: png
```

Default format can be set as well:

```yaml
format: png
routes:
    - "<id>/<width [0-9]+>x<height [0-9]+>"
```