### PR TITLE
Nette 2.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
     },
     "require": {
         "php": ">=5.4",
-        "nette/application": ">=2.2.0,<2.3.0",
-        "nette/di": ">=2.2.0,<2.3.0",
-        "nette/http": ">=2.2.0,<2.3.0",
-        "latte/latte": ">=2.2.0,<2.3.0",
-        "nette/utils": ">=2.2.0,<2.3.0"
+        "nette/application": ">=2.2.0,<2.4.0",
+        "nette/di": ">=2.2.0,<2.4.0",
+        "nette/http": ">=2.2.0,<2.4.0",
+        "latte/latte": ">=2.2.0,<2.4.0",
+        "nette/utils": ">=2.2.0,<2.4.0"
     },
     "autoload": {
         "classmap": ["src/"]


### PR DESCRIPTION
I have changed required version of Nette to 2.3.*. There are no BC breaks.