### PR TITLE
Add support for secured routes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,14 @@ This will result in following HTML:
 ```
 
 Creation of this file will handle your implementation of `DotBlue\WebImages\IProvider`.
+
+### HTTPS
+
+To toggle secured route flag use following syntax in your configuration:
+
+```
+webimages:
+    routes:
+        - mask: images/<id>-<width>x<height>.jpg
+          secured: true
+```

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -6,6 +6,7 @@
 
 namespace DotBlue\WebImages;
 
+use Nette\Application\Routers\Route as NetteRoute;
 use Nette\DI;
 
 
@@ -56,10 +57,14 @@ class Extension extends DI\CompilerExtension
 					$definition = [
 						'mask' => $definition,
 						'defaults' => [],
+						'secured' => FALSE,
 					];
 				} else {
 					if (!isset($definition['defaults'])) {
 						$definition['defaults'] = [];
+					}
+					if (!isset($definition['secured'])) {
+						$definition['secured'] = FALSE;
 					}
 				}
 
@@ -79,6 +84,7 @@ class Extension extends DI\CompilerExtension
 						$definition['mask'],
 						$definition['defaults'],
 						$this->prefix('@generator'),
+						$definition['secured'] ? NetteRoute::SECURED : 0,
 					])
 					->addTag($this->prefix('route'))
 					->setAutowired(FALSE);

--- a/src/Route.php
+++ b/src/Route.php
@@ -51,7 +51,7 @@ class Route extends Application\Routers\Route
 	 * @param  array
 	 * @param  Validator
 	 */
-	public function __construct($mask, array $defaults, Generator $generator)
+	public function __construct($mask, array $defaults, Generator $generator, $flags = 0)
 	{
 		$this->defaults = $defaults;
 		$this->generator = $generator;
@@ -74,7 +74,7 @@ class Route extends Application\Routers\Route
 		$defaults['presenter'] = 'Nette:Micro';
 		$defaults['callback'] = $this;
 
-		parent::__construct($mask, $defaults);
+		parent::__construct($mask, $defaults, $flags);
 	}
 
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -47,9 +47,9 @@ class Route extends Application\Routers\Route
 
 	/**
 	 * @param  string
-	 * @param  string
 	 * @param  array
-	 * @param  Validator
+	 * @param  Generator
+	 * @param  int|NULL
 	 */
 	public function __construct($mask, array $defaults, Generator $generator, $flags = 0)
 	{


### PR DESCRIPTION
Usage:

```
webimages:
    providers:
        - App\Services\ImageProvider(%wwwDir%/pydio/data/files/fotogalerie)
    routes:
        - mask: images/fotogalerie/<gallery>/<width>x<height>/<id>.jpg
          secured: true
```

No BC breaks
